### PR TITLE
Add comment support to DMMF conversion

### DIFF
--- a/src/utils/isdlToDmmf.ts
+++ b/src/utils/isdlToDmmf.ts
@@ -1,4 +1,4 @@
-import { ISDL, IGQLField, IGQLType, isTypeIdentifier, LegacyRelationalReservedFields, IComment } from 'prisma-datamodel'
+import { ISDL, IGQLField, IGQLType, isTypeIdentifier, IComment } from 'prisma-datamodel'
 import { Dictionary, keyBy } from './keyby'
 import fs from 'fs'
 


### PR DESCRIPTION
This forwards error hints from introspection to the datamodel v2 renderer.

Example:

```
/// Field name normalization failed because of a conflicting field name.
/// Could not auto-generate backwards relation field, field name would be ambiguous.
/// Please specify the name of this field and the name of the relation manually.
/// It references Person.birthLocation.
persons     Person[]    @relation("LocationPersonsToPersonBirthLocation")
```