### PR TITLE
feat: windows support

### DIFF
--- a/src/Lift.ts
+++ b/src/Lift.ts
@@ -191,13 +191,14 @@ export class Lift {
       }
 
       const platform = await getPlatform()
+      const extension = platform === 'windows' ? '.exe' : '' 
 
       const pathCandidates = [
         // ncc go home
         // tslint:disable-next-line
-        eval(`require('path').join(__dirname, '../node_modules/@prisma/photon/query-engine-${platform}')`), // for local dev
+        eval(`require('path').join(__dirname, '../node_modules/@prisma/photon/query-engine-${platform}${extension}')`), // for local dev
         // tslint:disable-next-line
-        eval(`require('path').join(__dirname, '../query-engine-${platform}')`), // for production
+        eval(`require('path').join(__dirname, '../query-engine-${platform}${extension}')`), // for production
       ]
 
       const pathsExist = await Promise.all(

--- a/src/LiftEngine.ts
+++ b/src/LiftEngine.ts
@@ -9,6 +9,7 @@ const debugStderr = debugLib('LiftEngine:stderr')
 const debugStdin = debugLib('LiftEngine:stdin')
 import fs from 'fs'
 import { now } from './utils/now'
+import { getPlatform } from '@prisma/get-platform';
 
 export interface LiftEngineOptions {
   projectDir: string
@@ -122,10 +123,12 @@ export class LiftEngine {
     return this.initPromise!
   }
   private internalInit(): Promise<void> {
-    return new Promise((resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
       try {
         const { PWD, ...rest } = process.env
-        this.child = spawn(this.binaryPath, ['-d', this.schemaPath], {
+        const platform = await getPlatform()
+        const extension = platform === 'windows' ? '.exe' : '' 
+        this.child = spawn(this.binaryPath + extension, ['-d', this.schemaPath], {
           cwd: this.projectDir,
           stdio: ['pipe', 'pipe', this.debug ? process.stderr : 'pipe'],
           env: {


### PR DESCRIPTION
This PR adds support for using lift on Windows:

- fix usage: binary name + extension

It depends on https://github.com/prisma/photonjs/pull/219

We think tests are failing because `@prisma/fetch-engine` and `@prisma/get-platform` are not published yet (maybe?).

Part of https://github.com/prisma/prisma2/issues/460

Co-authored-by: Divyendu Singh <singh@prisma.io>

closes https://github.com/prisma/lift/issues/22