### PR TITLE
keep comments intact when masking schema

### DIFF
--- a/src/utils/maskSchema.ts
+++ b/src/utils/maskSchema.ts
@@ -5,7 +5,7 @@ export function maskSchema(schema: string): string {
     .map(line => {
       const match = regex.exec(line)
       if (match) {
-        return `${' '.repeat(match.index)}url = "***"`
+        return `${line.slice(0, match.index)}url = "***"`
       }
       return line
     })


### PR DESCRIPTION
In my schema, the following lines were present:

```prisma
// TODO: Enable in production
// datasource postgresql {
//   provider = "postgresql"
//   url      = env("POSTGRESQL_URL")
//   enabled  = env("POSTGRESQL_URL")
// }
```

Due to the wrong handling of `url`, it ended up in the migrated schema like this:

```prisma
// TODO: Enable in production
// datasource postgresql {
//   provider = "postgresql"
     url = "***"
//   enabled  = env("POSTGRESQL_URL")
// }
```

This change aims to fix this issue.