### PR TITLE
Fix filtering of migrations in lift up

### DIFF
--- a/src/Lift.ts
+++ b/src/Lift.ts
@@ -832,8 +832,8 @@ export class Lift {
       return true
     })
 
-    const filterMigrations = (values: any[], n: string): any[] => {
-      if (!n.length) {
+    const filterMigrations = (values: any[], n: string | undefined): any[] => {
+      if (!n) {
         return values
       }
 
@@ -850,9 +850,9 @@ export class Lift {
     return {
       localMigrations,
       lastAppliedIndex,
-      appliedRemoteMigrations: filterMigrations(appliedRemoteMigrations.reverse(), String(appliedFilter)).reverse(),
+      appliedRemoteMigrations: filterMigrations(appliedRemoteMigrations.reverse(), appliedFilter).reverse(),
       sourceConfig,
-      migrationsToApply: filterMigrations(migrationsToApply, String(toApplyFilter)),
+      migrationsToApply: filterMigrations(migrationsToApply, toApplyFilter),
     }
   }
 }


### PR DESCRIPTION
String(undefined) === "undefined", not empty string.

The bug was introduced in da8ab2de2af8280003898fc22c60b5af53d14c94

We should probably have tests for filtering on `lift up`