### PR TITLE
Remove unused option from Lift Down help

### DIFF
--- a/src/cli/commands/LiftDown.ts
+++ b/src/cli/commands/LiftDown.ts
@@ -22,7 +22,6 @@ export class LiftDown implements Command {
 
     ${chalk.bold('Options')}
 
-      --auto-approve   Skip interactive approval before migrating
       -h, --help       Displays this help message
       -p, --preview    Preview the migration changes
 


### PR DESCRIPTION
Lift down does not uses the "--auto-approve" option (See #254), so it shouldn't appear in the help of the lift down command