### PR TITLE
Fix studio-server staticAssetDir path

### DIFF
--- a/src/Studio.ts
+++ b/src/Studio.ts
@@ -74,7 +74,7 @@ export class Studio {
             providerAliases,
           },
         },
-        staticAssetDir: path.resolve(__dirname, 'public'), // Overriding this directory since after NCC compilation, this won't resolve automatically
+        staticAssetDir: path.resolve(__dirname, '../public'), // Overriding this directory since after NCC compilation, this won't resolve automatically
       })
 
       await this.instance.start()


### PR DESCRIPTION
@timsuchanek Please take a look and let me know if this is indeed required. I was under the assumption that `__dirname` was not affected by compilation, but it looks like it is.